### PR TITLE
fixed bug when rotation is 0 or 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,15 @@ import numpy as np
 
 def draw_gradient_alpha_rectangle(frame, BGR_Channel, rectangle_position, rotate):
     (xMin, yMin), (xMax, yMax) = rectangle_position
+    height = yMax - yMin
+    width = xMax - xMin
     color = np.array(BGR_Channel, np.uint8)[np.newaxis, :]
-    mask1 = np.rot90(np.repeat(np.tile(np.linspace(1, 0, (rectangle_position[1][1]-rectangle_position[0][1])), ((rectangle_position[1][0]-rectangle_position[0][0]), 1))[:, :, np.newaxis], 3, axis=2), rotate) 
+    if rotate == 1 or rotate == 3:
+        mask1 = np.rot90(np.repeat(np.tile(np.linspace(1, 0, height), (width, 1))[:, :, np.newaxis], 3, axis=2), rotate)
+    elif rotate == 0 or rotate == 2:
+        mask1 = np.rot90(np.repeat(np.tile(np.linspace(1, 0, width), (height, 1))[:, :, np.newaxis], 3, axis=2), rotate)
+    else:
+        raise Exception(f"invalid rotation value (expected int 0-3): {rotate}")
     frame[yMin:yMax, xMin:xMax, :] = mask1 * frame[yMin:yMax, xMin:xMax, :] + (1-mask1) * color
 
     return frame

--- a/main.py
+++ b/main.py
@@ -3,8 +3,15 @@ import numpy as np
 
 def draw_gradient_alpha_rectangle(frame, BGR_Channel, rectangle_position, rotate):
     (xMin, yMin), (xMax, yMax) = rectangle_position
+    height = yMax - yMin
+    width = xMax - xMin
     color = np.array(BGR_Channel, np.uint8)[np.newaxis, :]
-    mask1 = np.rot90(np.repeat(np.tile(np.linspace(1, 0, (rectangle_position[1][1]-rectangle_position[0][1])), ((rectangle_position[1][0]-rectangle_position[0][0]), 1))[:, :, np.newaxis], 3, axis=2), rotate) 
+    if rotate == 1 or rotate == 3:
+        mask1 = np.rot90(np.repeat(np.tile(np.linspace(1, 0, height), (width, 1))[:, :, np.newaxis], 3, axis=2), rotate)
+    elif rotate == 0 or rotate == 2:
+        mask1 = np.rot90(np.repeat(np.tile(np.linspace(1, 0, width), (height, 1))[:, :, np.newaxis], 3, axis=2), rotate)
+    else:
+        raise Exception(f"invalid rotation value (expected int 0-3): {rotate}")
     frame[yMin:yMax, xMin:xMax, :] = mask1 * frame[yMin:yMax, xMin:xMax, :] + (1-mask1) * color
 
     return frame


### PR DESCRIPTION
Thanks for writing this, it was super helpful! I did find a bug that happens when rotation is 0 or 2, but only for gradients that are not square. This PR fixes that, but feel free to fix it in a more elegant way if you want.